### PR TITLE
adds periodic kernel, covariance matrix from regression.predict(), and versions to support jax-metal

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,21 +1,21 @@
 import argparse
-from collections.abc import Callable
-from typing import NamedTuple
 
-# import cola
-# import gpjax as gpx
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from IPython import embed  # noqa
+import optax
+import tqdm
 from jax import random
 from jax.typing import ArrayLike
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, PyTree
 
-from dgp.kernels import eq, cov_matrix
 import dgp.regression as gpr
+from dgp.kernels import cov_matrix, eq
+
+from IPython import embed  # noqa
 
 _jitter = 1e-6
+
 # Set JAX to use 64bit:
 jax.config.update("jax_enable_x64", True)
 
@@ -35,16 +35,6 @@ def generate_toydata(
 
     X = jnp.stack([xx, yy], axis=-1).reshape(x_array.shape[0] * y_array.shape[0], 2)
 
-    # kernel = gpx.kernels.RBF(
-    #    lengthscale=jnp.array([1.0, 1.0]), variance=jnp.array([1.0])
-    # )
-    # K = kernel.gram(X)
-    ## L = jnp.linalg.cholesky(K)
-    # L = cola.Cholesky()(K + _jitter * cola.ops.I_like(K))
-
-    # K2 = K.to_dense()
-    # L2 = jnp.linalg.cholesky(K2 + _jitter * jnp.eye(K2.shape[0]))
-
     k = eq(lengthscale=jnp.array([1.0, 1.0]), variance=1.0)
     K = cov_matrix(k, X, X)
     L = jnp.linalg.cholesky(K + _jitter * jnp.eye(K.shape[0]))
@@ -52,7 +42,6 @@ def generate_toydata(
     u = random.normal(key, shape=[X.shape[0], 1])
 
     f = L @ u
-    # y2 = L2 @ u
 
     # Derivative of y:
     f_grid = f.reshape(y_array.shape[0], x_array.shape[0])
@@ -69,7 +58,6 @@ def main() -> None:
     key, subkey = random.split(key)
 
     # Set up toy dataset:
-
     x_array = jnp.linspace(0, 10, args.resx)
     y_array = jnp.linspace(0, 5, args.resy)
 
@@ -109,27 +97,81 @@ def main() -> None:
     Xtrain = X[train_idx]
     dftrain = df[train_idx]
 
-    k = eq(lengthscale=jnp.array([1.0, 1.0]), variance=1.0)
+    # ==================== Optimise the GP ====================
 
+    # Define the covariance function to use and the initial hyperparameters:
+    kernel = eq
+    params = dict(lengthscale=jnp.array([2.0, 2.0]), variance=2.0)
+
+    optimiser = optax.adam(1e-1)
+    opt_state = optimiser.init(params)
+
+    def objective(
+        params: PyTree,
+        X: Float[Array, "N D"],
+        y: Float[Array, "N"],
+    ) -> float:
+        k = kernel(**params)
+        gp = gpr.fit(X, y, k)
+
+        return -gpr.logp(gp)
+
+    loss_grad_fn = jax.value_and_grad(objective)
+
+    @jax.jit
+    def step_fn(
+        params: PyTree,
+        opt_state: optax.OptState,
+        X: Float[Array, "N D"],
+        y: Float[Array, "N"],
+    ) -> tuple[PyTree, optax.OptState, float]:
+        neg_logp, grad = loss_grad_fn(params, X, y)
+        update, opt_state = optimiser.update(grad, opt_state)
+        params = optax.apply_updates(params, update)
+        return params, opt_state, neg_logp
+
+    logger = dict(
+        epoch=[],
+        logp=[],
+    )
+    pbar = tqdm.tqdm(range(args.num_epochs), desc="Epoch")
+    for epoch in pbar:
+        try:
+            params, opt_state, neg_logp = step_fn(params, opt_state, Xtrain, dftrain)
+
+            logger["epoch"].append(epoch)
+            logger["logp"].append(-neg_logp)
+
+            pbar.set_description(f"Epoch: {epoch}, log marginal: {-neg_logp:g}")
+
+        except KeyboardInterrupt:
+            break
+
+    print("Optimised parameters:")
+    for key, val in params.items():
+        print(f"  {key} = {val}")
+
+    # Use the optimised parameters:
+    k = eq(**params)
     gp = gpr.fit(Xtrain, dftrain, k)
 
     f_pred, covar = gpr.predict(X, gp)
     std = jnp.sqrt(jnp.diag(covar))
 
+    # Reshape to grid and compute gradients:
     f_pred = f_pred.reshape(args.resy, args.resx)
     std = std.reshape(args.resy, args.resx)
-    # f_diff = f_pred - f
 
     dfdy_pred, dfdx_pred = jnp.gradient(f_pred)
     df_pred = jnp.dstack((dfdx_pred, dfdy_pred)).reshape(-1, 2)
-    # f_diff = jnp.sqrt((dfdx_pred - dfdx) ** 2 + (dfdy_pred - dfdy) ** 2)
 
-    # Cosine similarity between gradients:
+    # Cosine similarity between predicted and true gradients:
     cosine_similarity = jnp.sum(df * df_pred, axis=1) / jnp.sqrt(
         jnp.sum(df**2, axis=1) * jnp.sum(df_pred**2, axis=1)
     )
     cosine_similarity = cosine_similarity.reshape(args.resy, args.resx)
 
+    # ==================== Plotting ====================
     fig, ax = plt.subplots(
         3,
         2,
@@ -143,7 +185,7 @@ def main() -> None:
     )
     ax[0, 0].scatter(*Xtrain.T, s=12, facecolor=plt.cm.Oranges(0.5), alpha=1)
 
-    ax[0, 1].quiver(xx, yy, dfdx.ravel(), dfdy.ravel(), f.ravel())
+    ax[0, 1].quiver(xx, yy, dfdx.ravel(), dfdy.ravel(), f.ravel(), angles="xy")
 
     pred_c = ax[1, 0].imshow(
         f_pred,
@@ -163,6 +205,10 @@ def main() -> None:
         vmax=1,
     )
 
+    ax[2, 0].plot(
+        logger["epoch"], logger["logp"], c="C0", label="Marginal log-likelihood"
+    )
+
     var_c = ax[2, 1].imshow(
         std,
         extent=[x_array[0], x_array[-1], y_array[0], y_array[-1]],
@@ -172,10 +218,10 @@ def main() -> None:
 
     ax[0, 1].set_xlim(x_array[0], x_array[-1])
     ax[0, 1].set_ylim(y_array[0], y_array[-1])
-    # ax[1].set_ylim(y_array[-1], y_array[0])
+    ax[0, 1].set_ylim(y_array[-1], y_array[0])
     ax[0, 1].set_aspect("equal")
-    # ax[1].set_aspect("equal", adjustable="datalim")
-    # ax[1].autoscale()
+
+    ax[2, 0].set_ylim(bottom=-100, top=300)
 
     plt.colorbar(true_c, ax=ax[0, 0])
     plt.colorbar(pred_c, ax=ax[1, 0])
@@ -183,10 +229,14 @@ def main() -> None:
     plt.colorbar(var_c, ax=ax[2, 1])
 
     ax[0, 0].set_title("True function")
-    ax[0, 1].set_title("Function gradient")
+    ax[0, 1].set_title("Gradient field")
     ax[1, 0].set_title("Predicted function")
     ax[1, 1].set_title("Cosine similarity of gradients")
+    ax[2, 0].set_title("Marginal log-likelihood")
     ax[2, 1].set_title("Predictive uncertainty (1 std)")
+
+    ax[2, 0].set_xlabel("Epoch")
+    ax[2, 0].set_ylabel("Marginal log-likelihood")
 
     plt.show()
     # plt.savefig("gp_on_derivative_obs_toy_data.pdf")
@@ -196,10 +246,13 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--seed", type=int, default=0, help="Random seed.")
     parser.add_argument(
-        "--resx", type=int, default=50, help="Surface resolution in x direction."
+        "--resx", type=int, default=64, help="Surface resolution in x direction."
     )
     parser.add_argument(
-        "--resy", type=int, default=25, help="Surface resolution in y direction."
+        "--resy", type=int, default=32, help="Surface resolution in y direction."
+    )
+    parser.add_argument(
+        "--num_epochs", type=int, default=1000, help="Number of training epochs."
     )
 
     args = parser.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,17 @@ unfixable = []
 [tool.ruff.lint.flake8-annotations]
 allow-star-arg-any = true
 
+[tool.ruff.lint.isort]
+section-order = [
+  "future",
+  "standard-library",
+  "first-party",
+  "third-party",
+  "local-folder",
+  "dgp",
+  "ipython",
+]
+
 [tool.ruff.lint.isort.sections]
-# Put IPython into its own section.
-"IPython" = ["IPython"]
+ipython = ["IPython"]
+dgp = ["dgp"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dgp"
 version = "0.0.1"
 authors = [{ name = "Kristoffer Stensbo-Smidt", email = "kss@prior.info" }]
 description = "Implementations of Gaussian processes for derivative observations."
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 dynamic = ["dependencies", "optional-dependencies"]
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,6 @@ mypy >= 1.8.0
 
 # For example scripts:
 tqdm>=4.66
+optax>=0.1.9
+ipython>=8.22.0
+matplotlib>=3.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,6 @@ ruff >= 0.3.0
 
 # static type checking
 mypy >= 1.8.0
+
+# For example scripts:
+tqdm>=4.66

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 jax[cpu]>=0.4
 jaxtyping>=0.2.28
+jaxlib
+optax>=0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-jax[cpu]
-ipython>=8.22.0
-matplotlib>=3.7.0
-numpy>=1.26.0
-#gpjax>=0.8.2
-scipy>=1.13.0
-optax>=0.1.9
+jax[cpu]>=0.4
 jaxtyping>=0.2.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ numpy>=1.26.0
 scipy>=1.13.0
 optax>=0.1.9
 jaxtyping>=0.2.28
-tqdm>=4.66.2

--- a/src/dgp/kernels.py
+++ b/src/dgp/kernels.py
@@ -97,7 +97,7 @@ def derivative_cov_func(kernel: Callable) -> CovMatrix:
     )
 
     def B(dx: Float[Array, "N D"], y: Float[Array, "M 1"]) -> Float[Array, "N M"]:
-        batched_matrix = ddx_cov(dx, y)
+        batched_matrix = -ddx_cov(dx, y)
         matrix = jnp.concatenate(batched_matrix, axis=0)
         return matrix
 
@@ -111,7 +111,7 @@ def derivative_cov_func(kernel: Callable) -> CovMatrix:
     )
 
     def C(x: Float[Array, "M 1"], dy: Float[Array, "N D"]) -> Float[Array, "M N"]:
-        batched_matrix = ddy_cov(x, dy)
+        batched_matrix = -ddy_cov(x, dy)
         matrix = jnp.concatenate(batched_matrix, axis=1)
         return matrix
 

--- a/src/dgp/regression.py
+++ b/src/dgp/regression.py
@@ -3,9 +3,9 @@ from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Float, PyTree
+from jaxtyping import Array, Float
 
-from dgp.kernels import derivative_cov_func, CovMatrix
+from dgp.kernels import CovMatrix, derivative_cov_func
 
 _jitter = 1e-6
 
@@ -44,7 +44,7 @@ def predict(
 
 def logp(gp: GP) -> float:
     return (
-        -0.5 * jnp.inner(gp.y, gp.alpha)
+        -0.5 * jnp.dot(gp.y.ravel(), gp.alpha.ravel())
         - jnp.sum(jnp.log(jnp.diag(gp.L)))
         - 0.5 * gp.X.shape[0] * jnp.log(2 * jnp.pi)
     )

--- a/src/dgp/regression.py
+++ b/src/dgp/regression.py
@@ -19,12 +19,17 @@ class GP(NamedTuple):
     cov_matrices: CovMatrix
 
 
-def fit(X: Float[Array, "N D"], y: Float[Array, "N"], kernel: Callable) -> GP:
+def fit(
+    X: Float[Array, "N D"],
+    y: Float[Array, "N"],
+    kernel: Callable,
+    jitter: float = _jitter,
+) -> GP:
     cov_matrices = derivative_cov_func(kernel)
 
     K = cov_matrices.A(X, X)
 
-    L = jax.scipy.linalg.cholesky(K + _jitter * jnp.eye(K.shape[0]), lower=True)
+    L = jax.scipy.linalg.cholesky(K + jitter * jnp.eye(K.shape[0]), lower=True)
     alpha = jax.scipy.linalg.cho_solve((L, True), y.reshape(-1, 1))
 
     return GP(kernel, X, y, L, alpha, cov_matrices)

--- a/src/dgp/regression.py
+++ b/src/dgp/regression.py
@@ -9,7 +9,7 @@ from jaxtyping import Array, Float, PyTree
 
 from dgp.kernels import CovMatrix, derivative_cov_func
 
-_jitter = 1e-6
+_jitter = 1e-4
 
 
 class GP(NamedTuple):
@@ -49,8 +49,8 @@ def predict(
     return f_pred, covar
 
 
-def logp(gp: GP) -> float:
-    return float(
+def logp(gp: GP) -> Float:
+    return (
         -0.5 * jnp.dot(gp.y.ravel(), gp.alpha.ravel())
         - jnp.sum(jnp.log(jnp.diag(gp.L)))
         - 0.5 * gp.X.shape[0] * jnp.log(2 * jnp.pi)


### PR DESCRIPTION
lowers strictness of dependencies for working with the core package excluding the demo script/nb

may not be the best idea depending on how small you want to make the package. if you want more full-featured demos, then probably better to insist on stricter dependencies.

these versions are compatible with apple silicon running jax-metal 0.0.6